### PR TITLE
chore: Add a good-first-issue-candidate issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
@@ -13,9 +13,9 @@ body:
         The goal of this issue (and all other issues labeled with) [**'Good First Issue'**](https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Ahiero-ledger+archived%3Afalse+label%3A%22good+first+issue%22+) is to help you make your first contribution to Hiero.
 
         Before submitting:
-        * Try searching the existing issues and discussions to see if something similar has been discussed previously
-        * Try opening a GitHub discussion first to gather feedback and reach consensus
-        * If this is a major enhancement, please open a [Hiero Improvement Proposal](https://github.com/hiero-ledger/hiero-improvement-proposals)
+        * Try searching the existing issues and discussions to see if something similar has been discussed previously.
+        * Try opening a GitHub discussion first to gather feedback and reach consensus.
+        * If this is a major enhancement, please open a [Hiero Improvement Proposal](https://github.com/hiero-ledger/hiero-improvement-proposals).
 
         ------
   - type: textarea


### PR DESCRIPTION
## Description

This pull request adds a new GitHub issue template designed to help first-time contributors suggest "Good First Issue" candidates. The template guides users through describing problems, proposing solutions, and outlining implementation steps, with additional resources and instructions for contributing.

New contributor support:

* Added `.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml` to provide a structured, beginner-friendly template for suggesting "Good First Issue" candidates, including detailed instructions, contribution workflow, and resource links.