### PR TITLE
chore: Add App Requests discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/app-requests.yaml
+++ b/.github/DISCUSSION_TEMPLATE/app-requests.yaml
@@ -1,4 +1,4 @@
-# Template metadata
+ult# Template metadata
 title: "GitHub App Integration Request"
 labels: ["app-request"]
 
@@ -48,11 +48,21 @@ body:
         @hiero-ledger/sec-ops
         @hiero-ledger/github-maintainers
 
-  - type: input
+  - type: textarea
     id: additional_teams
     attributes:
       label: "Additional Teams to Include (optional)"
       description: "Add any other organization teams to notify about this request. Separate multiple teams with spaces."
-      placeholder: "@hiero-ledger/<team-x> @hiero-ledger/<team-y> @<github-user-name>"
+      placeholder: |
+        Please include the following teams:
+        - @hiero-ledger/security-maintainers
+        - @hiero-ledger/prod-security
+        - @hiero-ledger/sec-ops
+        - @hiero-ledger/github-maintainers
+      value: | 
+        @hiero-ledger/security-maintainers
+        @hiero-ledger/prod-security
+        @hiero-ledger/sec-ops
+        @hiero-ledger/github-maintainers
     validations:
       required: false


### PR DESCRIPTION
## Description

This pull request adds a new discussion template for requesting GitHub App integrations. The template standardizes how team members can request new app integrations, ensuring all necessary information is collected up front.

**New GitHub App Integration Request Template:**

- Introduces a discussion template at `.github/DISCUSSION_TEMPLATE/app-requests.yaml` for requesting GitHub App integrations, including required fields for app name, affected repositories, and justification.
- Provides a section to specify additional teams to notify, supplementing a default list of included teams.

## Related Issue(s)

#32 