### PR TITLE
Adjust pass_threshold for maintainers

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -67,7 +67,7 @@ profiles:
     #
     # The percentage is calculated based on the number of votes in favor and the
     # number of allowed voters (see allowed_voters field below for more details).
-    pass_threshold: 67
+    pass_threshold: 66.66
 
     # Allowed voters (optional)
     #
@@ -178,14 +178,14 @@ profiles:
 
   allMembers:
     duration: 1w
-    pass_threshold: 67
+    pass_threshold: 66.66
     close_on_passing: true
     close_on_passing_min_wait: "3 days"
     periodic_status_check: "1 day"
 
   allMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -225,7 +225,7 @@ profiles:
 
   githubMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -234,7 +234,7 @@ profiles:
 
   hieroMirrorNodeMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -243,7 +243,7 @@ profiles:
 
   hieroLocalNodeMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -252,7 +252,7 @@ profiles:
 
   hieroSdkPythonMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -261,7 +261,7 @@ profiles:
 
   hieroSdkSwiftMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -270,7 +270,7 @@ profiles:
 
   hieroDidSdkPythonMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -279,7 +279,7 @@ profiles:
 
   hieroSdkRustMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -288,7 +288,7 @@ profiles:
 
   hieroSdkJavaMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -297,7 +297,7 @@ profiles:
 
   hieroSdkJsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -306,7 +306,7 @@ profiles:
 
   hieroSdkCppMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -315,7 +315,7 @@ profiles:
 
   hieroSdkTckMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -324,7 +324,7 @@ profiles:
 
   hieroSdkGoMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -333,7 +333,7 @@ profiles:
 
   hieroSoloActionMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -342,7 +342,7 @@ profiles:
 
   hieroGradleConventionsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -351,7 +351,7 @@ profiles:
 
   hieroBlockNodeMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -360,7 +360,7 @@ profiles:
 
   hieroConsensusNodeMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -369,7 +369,7 @@ profiles:
 
   hieroProtobufsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -378,7 +378,7 @@ profiles:
 
   hieroCliMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -387,7 +387,7 @@ profiles:
 
   hieroDocsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -396,7 +396,7 @@ profiles:
 
   hieroMirrorNodeExplorerMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -405,7 +405,7 @@ profiles:
 
   hieroJsonRpcRelayMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -414,7 +414,7 @@ profiles:
 
   hieroHederiumMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -423,7 +423,7 @@ profiles:
 
   hieroIdentityStandardsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -432,7 +432,7 @@ profiles:
 
   hieroImprovementProposalsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -441,7 +441,7 @@ profiles:
 
   hieroWebsiteMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -450,7 +450,7 @@ profiles:
 
   homebrewToolsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -459,7 +459,7 @@ profiles:
 
   securityMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -468,7 +468,7 @@ profiles:
 
   sdkCollaborationHubMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -477,7 +477,7 @@ profiles:
 
   soloMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -486,7 +486,7 @@ profiles:
 
   tscEligibilityCheckMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:
@@ -495,7 +495,7 @@ profiles:
 
   hashgraphOnlineStandardsSdkJsMaintainers:
     duration: 2w
-    pass_threshold: 67
+    pass_threshold: 66.66
     periodic_status_check: "2 days"
     close_on_passing: false
     allowed_voters:


### PR DESCRIPTION
## Description

This pull request updates the voting threshold for passing proposals in the `.gitvote.yml` configuration file. The change standardizes the `pass_threshold` value across all voting profiles from 67% to 66.66%, to allow for more precise to better reflect a two-thirds majority.

67% was too restrictive. Gitvote goes to the hundredths precision. Modified the requirement to be 66.66% so that when we reach 2/3rds vote (66.67%) we exceed the passing threshold.

Voting configuration updates:

* Changed `pass_threshold` from 67 to 66.66 in the main profiles section and for all individual voting profiles, including `allMembers`, `allMaintainers`, `githubMaintainers`, and various `hiero*` and other maintainer groups. [[1]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L70-R70) [[2]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L181-R188) [[3]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L228-R228) [[4]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L237-R237) [[5]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L246-R246)
* Applied the same `pass_threshold` update to specialized profiles such as `securityMaintainers`, `soloMaintainers`, `tscEligibilityCheckMaintainers`, and others. [[1]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L462-R462) [[2]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L480-R480) [[3]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L489-R489)
* Ensured consistency for all remaining profiles, including SDK, website, documentation, and standards maintainers. [[1]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L291-R291) [[2]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L444-R444) [[3]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L390-R390) [[4]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L426-R426) [[5]](diffhunk://#diff-4afc5f793803c9f914485bf8f8811a1acf3a309b2934768684e2755e91da5707L498-R498)

## Related Issue(s)

Fixes #40
