### PR TITLE
fix: markdown to text area to render workflow and question section in…

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
@@ -67,19 +67,6 @@ body:
         - [ ] **Work on the issue:** Follow the detailed description in our [CONTRIBUTING.md](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md) file.
         - [ ] **You did it 🎉:** We will merge the fix in the main branch. Thanks for being part of the Hiero community as an open-source contributor!
 
-  # - type: textarea
-  #   id: hacktoberfest
-  #   attributes:
-  #     label: Hacktoberfest
-  #     description: Hacktoberfest info (hidden until October 2026)
-  #     value: |
-  #       ## :jack_o_lantern: Hacktoberfest :jack_o_lantern:
-
-  #       During the [Hacktoberfest](https://hacktoberfest.digitalocean.com) event we try to mark all PRs that solve any good first issue with the `hacktoberfest-accepted` label.
-  #       If you want to resolve this issue as part of Hacktoberfest and we missed adding the label, simply add a comment to the issue or PR, and we will add it.
-  #   validations:
-  #     required: false
-
   - type: textarea
     id: additional_questions
     attributes:
@@ -92,3 +79,15 @@ body:
         Additionally, we invite you to join our community on our [Discord](https://discord.gg/kEnnmB9A) server or attend our [public community calls](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
 
         A general manual about open-source contributions can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
+
+        ------
+
+  - type: markdown
+    attributes:
+      value: |
+        ## :jack_o_lantern: Hacktoberfest :jack_o_lantern:
+        
+        At the time of the [Hacktoberfest](https://hacktoberfest.digitalocean.com) event we try to mark all PRs that solve any good first issue with the `hacktoberfest-accepted` label.
+        If you want to resolve this issue as part of Hacktoberfest and we missed adding the label, simply add a comment to the issue or PR, and we will add it.
+        
+        ------


### PR DESCRIPTION
… good first issue template

**Description**:
The good first issue template is not rendering: workflow, hacktoberfest, question sections on issue posting.
This may be because of markdown formatting.
-->

**Related issue(s)**:

Fixes #42

**Notes for reviewer**:
I have hidden hacktoberfest from view because it is no longer active

TESTED on a fork - I think it works nicely, this is the result:
https://github.com/exploreriii/hiero_sdk_python/issues/37
(labels will not work as i don't have any, and i had to comment out feature as that is for an organisation)
